### PR TITLE
Add action to load all active cues to the programmer

### DIFF
--- a/JuceLibraryCode/JuceHeader.h
+++ b/JuceLibraryCode/JuceHeader.h
@@ -52,7 +52,7 @@ namespace ProjectInfo
 {
     const char* const  projectName    = "BlinderKitten";
     const char* const  companyName    = "Norbert Rostaing";
-    const char* const  versionString  = "1.0.1b48";
+    const char* const  versionString  = "1.0.1b48-sbo";
     const int          versionNumber  = 0x10001;
 }
 #endif

--- a/Source/Brain.h
+++ b/Source/Brain.h
@@ -171,4 +171,6 @@ public:
     void resetRandomSeed(int seed);
 
     void showWindow(String name);
+
+    void loadFromActiveCues();
 };

--- a/Source/Common/Action/ActionManager.cpp
+++ b/Source/Common/Action/ActionManager.cpp
@@ -117,6 +117,7 @@ ActionFactory::ActionFactory()
     defs.add(Factory<Action>::Definition::createDef("Input Panel", "Reset random Seed", &InputPanelAction::create)->addParam("actionType", InputPanelAction::IP_RANDOMSEED));
     defs.add(Factory<Action>::Definition::createDef("Input Panel", "Select Window", &InputPanelAction::create)->addParam("actionType", InputPanelAction::IP_SELECTWINDOW));
     defs.add(Factory<Action>::Definition::createDef("Input Panel", "Save", &InputPanelAction::create)->addParam("actionType", InputPanelAction::IP_SAVE));
+    defs.add(Factory<Action>::Definition::createDef("Input Panel", "Load from active cues", &InputPanelAction::create)->addParam("actionType", InputPanelAction::IP_LOADFROMACTIVECUES));
 
     defs.add(Factory<Action>::Definition::createDef("Encoder", "Encoder Value", &EncoderAction::create)->addParam("actionType", EncoderAction::ENC_VALUE));
     defs.add(Factory<Action>::Definition::createDef("Encoder", "Encoder Select", &EncoderAction::create)->addParam("actionType", EncoderAction::ENC_SELECT));

--- a/Source/Definitions/Actions/InputPanelAction.cpp
+++ b/Source/Definitions/Actions/InputPanelAction.cpp
@@ -153,6 +153,13 @@ void InputPanelAction::setValueInternal(var value, String origin, bool isRelativ
             });
         }
         break;
+
+    case IP_LOADFROMACTIVECUES:
+        if (val > 0) {
+            Brain::getInstance()->loadFromActiveCues();
+        }
+        break;
+
     }
 
 }

--- a/Source/Definitions/Actions/InputPanelAction.h
+++ b/Source/Definitions/Actions/InputPanelAction.h
@@ -19,7 +19,7 @@ public:
     InputPanelAction(var params);
     ~InputPanelAction();
 
-    enum ActionType { IP_PRESS, IP_GM, IP_KILLCL, IP_OFFCL, IP_STOPFX, IP_STOPCAR, IP_RANDOMSEED, IP_SELECTWINDOW, IP_SAVE};
+    enum ActionType { IP_PRESS, IP_GM, IP_KILLCL, IP_OFFCL, IP_STOPFX, IP_STOPCAR, IP_RANDOMSEED, IP_SELECTWINDOW, IP_SAVE, IP_LOADFROMACTIVECUES };
     ActionType actionType;
     EnumParameter* targetButton;
     IntParameter* randomSeed;


### PR DESCRIPTION
The goal of this PR is to be able to load all the active Cues to the Programmer (main use is for Theater, to create a scene from Cues with faders (typically groups of fixtures)), to be able to register a new Cue (typically in the main conduit) from the selected setup.

Some limitation :

* Go through all commands of the active cues and copy it to the programmer, using HTP Level of the cue for the HTP values
* Support only Values (preset are not supported here)