### PR TITLE
Save DMX Tester interface and layout viewer in session file

### DIFF
--- a/Source/BKEngine.cpp
+++ b/Source/BKEngine.cpp
@@ -100,7 +100,8 @@ BKEngine::BKEngine() :
 	virtualParamsContainer("Virtual Playbacks Settings"),
 	uiParamsContainer("UI Settings"),
 	loadWindowContainer("Cuelist load window"),
-	dmxTesterWindowContainer("DMX Tester window")
+	dmxTesterWindowContainer("DMX Tester window"),
+	layoutViewerContainer("Layout Viewer")
 	//defaultBehaviors("Test"),
 	//ossiaFixture(nullptr)
 {
@@ -124,6 +125,7 @@ BKEngine::BKEngine() :
 	ProjectSettings::getInstance()->addChildControllableContainer(&uiParamsContainer);
 	ProjectSettings::getInstance()->addChildControllableContainer(&loadWindowContainer);
 	ProjectSettings::getInstance()->addChildControllableContainer(&dmxTesterWindowContainer);
+	ProjectSettings::getInstance()->addChildControllableContainer(&layoutViewerContainer);
 
 	tapTempoHistory = genericSettingsContainer.addIntParameter("Tap tempo history", "number of hits in history to calculate tempo", 8, 1);
 	tapTempoHistory->addParameterListener(this);
@@ -245,6 +247,10 @@ BKEngine::BKEngine() :
 	dmxTesterInterface->targetType = TargetParameter::CONTAINER;
 	dmxTesterInterface->customGetTargetContainerFunc = &InterfaceManager::showAndGetInterfaceOfType<DMXInterface>;
 	dmxTesterInterface->maxDefaultSearchLevel = 0;
+
+	layoutViewerLayout = layoutViewerContainer.addTargetParameter("Layout", "", LayoutManager::getInstance());
+	layoutViewerLayout->targetType = TargetParameter::CONTAINER;
+	layoutViewerLayout->maxDefaultSearchLevel = 0;
 
 
 	mainBrain = Brain::getInstance();

--- a/Source/BKEngine.cpp
+++ b/Source/BKEngine.cpp
@@ -99,7 +99,8 @@ BKEngine::BKEngine() :
 	trackerContainer("Tracker Settings"),
 	virtualParamsContainer("Virtual Playbacks Settings"),
 	uiParamsContainer("UI Settings"),
-	loadWindowContainer("Cuelist load window")
+	loadWindowContainer("Cuelist load window"),
+	dmxTesterWindowContainer("DMX Tester window")
 	//defaultBehaviors("Test"),
 	//ossiaFixture(nullptr)
 {
@@ -122,6 +123,7 @@ BKEngine::BKEngine() :
 	ProjectSettings::getInstance()->addChildControllableContainer(&virtualParamsContainer);
 	ProjectSettings::getInstance()->addChildControllableContainer(&uiParamsContainer);
 	ProjectSettings::getInstance()->addChildControllableContainer(&loadWindowContainer);
+	ProjectSettings::getInstance()->addChildControllableContainer(&dmxTesterWindowContainer);
 
 	tapTempoHistory = genericSettingsContainer.addIntParameter("Tap tempo history", "number of hits in history to calculate tempo", 8, 1);
 	tapTempoHistory->addParameterListener(this);
@@ -237,6 +239,13 @@ BKEngine::BKEngine() :
 	loadWindowHeight = loadWindowContainer.addIntParameter("Windows Height", "", 610,100);
 	loadWindowButtonPerLine = loadWindowContainer.addIntParameter("Buttons per line", "", 5,1);
 	loadWindowButtonHeight = loadWindowContainer.addIntParameter("Button height", "", 40,30);
+
+
+	dmxTesterInterface = dmxTesterWindowContainer.addTargetParameter("Interface", "", InterfaceManager::getInstance());
+	dmxTesterInterface->targetType = TargetParameter::CONTAINER;
+	dmxTesterInterface->customGetTargetContainerFunc = &InterfaceManager::showAndGetInterfaceOfType<DMXInterface>;
+	dmxTesterInterface->maxDefaultSearchLevel = 0;
+
 
 	mainBrain = Brain::getInstance();
 	currentDMXChannelView = nullptr;

--- a/Source/BKEngine.h
+++ b/Source/BKEngine.h
@@ -92,6 +92,9 @@ public:
 	IntParameter* loadWindowButtonPerLine;
 	IntParameter* loadWindowButtonHeight;
 
+	ControllableContainer dmxTesterWindowContainer;
+	TargetParameter* dmxTesterInterface;
+
 
 	void createNewGraphInternal() override;
 

--- a/Source/BKEngine.h
+++ b/Source/BKEngine.h
@@ -95,6 +95,9 @@ public:
 	ControllableContainer dmxTesterWindowContainer;
 	TargetParameter* dmxTesterInterface;
 
+	ControllableContainer layoutViewerContainer;
+	TargetParameter* layoutViewerLayout;
+
 
 	void createNewGraphInternal() override;
 

--- a/Source/UI/DMXChannelView.cpp
+++ b/Source/UI/DMXChannelView.cpp
@@ -32,14 +32,14 @@ DMXChannelView::DMXChannelView() :
 	viewport.setViewedComponent(&channelContainer);
 	addKeyListener(this);
 	InterfaceManager::getInstance()->addAsyncManagerListener(this);
-	dynamic_cast<BKEngine*>(BKEngine::mainEngine)->currentDMXChannelView = this;
+	engine = dynamic_cast<BKEngine*>(BKEngine::mainEngine);
+	engine->currentDMXChannelView = this;
 }
 
 DMXChannelView::~DMXChannelView()
 {
-	BKEngine* e = dynamic_cast<BKEngine*>(BKEngine::mainEngine);
-	if (e->currentDMXChannelView == this) {
-		e->currentDMXChannelView = nullptr;
+	if (engine->currentDMXChannelView == this) {
+		engine->currentDMXChannelView = nullptr;
 	}
 	if (InterfaceManager::getInstanceWithoutCreating()) InterfaceManager::getInstance()->removeAsyncManagerListener(this);
 	setCurrentInterface(nullptr);

--- a/Source/UI/DMXChannelView.h
+++ b/Source/UI/DMXChannelView.h
@@ -49,7 +49,8 @@ class DMXChannelView :
     public InterfaceManager::AsyncListener,
     public ComboBox::Listener,
     public Inspectable::InspectableListener,
-    public KeyListener
+    public KeyListener,
+    public ParameterListener
 {
 public:
     juce_DeclareSingleton(DMXChannelView, true);
@@ -94,6 +95,7 @@ public:
     bool keyPressed(const KeyPress& key, Component* originatingComponent);
 
     void inspectableDestroyed(Inspectable* i) override;
+    void parameterValueChanged(Parameter* p) override;
 
     static DMXChannelView* create(const String& name) { return new DMXChannelView(); }
 

--- a/Source/UI/DMXChannelView.h
+++ b/Source/UI/DMXChannelView.h
@@ -12,6 +12,7 @@
 #include "JuceHeader.h"
 #include "Definitions/Interface/InterfaceManager.h"
 
+class BKEngine;
 class DMXInterface;
 class DMXChannelView;
 
@@ -61,6 +62,8 @@ public:
 
     //std::unique_ptr<BoolButtonToggleUI> testingUI;
     std::unique_ptr<FloatSliderUI> flashValue;
+
+    BKEngine* engine;
 
     ComboBox dmxList;
     OwnedArray<DMXChannelItem> channelItems;

--- a/Source/UI/LayoutViewer.h
+++ b/Source/UI/LayoutViewer.h
@@ -21,7 +21,8 @@ class LayoutViewer :
     public LayoutManager::AsyncListener,
     public ChangeListener,
     public Timer,
-    public DragAndDropTarget
+    public DragAndDropTarget,
+    public ParameterListener
 
 {
 public:
@@ -62,11 +63,12 @@ public:
     void resetClickColour();
 
     void comboBoxChanged(ComboBox* comboBoxThatHasChanged) override;
+    void parameterValueChanged(Parameter* p) override;
     Layout* selectedLayout = nullptr;
     void buttonStateChanged(Button*) override;
     void buttonClicked(Button*) override;
 
-    void selectLayout(int id);
+    void selectLayout(Layout* l);
 
     void resized() override;
     int currentWidth = 0; 


### PR DESCRIPTION
I use the DMX Tester view a lot to see what's going on so I'd like to restore the universe selection when starting up.