### PR TITLE
Add a keybind for Cue List Go Back

### DIFF
--- a/Source/MainComponentCommands.cpp
+++ b/Source/MainComponentCommands.cpp
@@ -65,6 +65,8 @@ namespace BlinderKittenCommandId
 	static const int keyHighlight = 0x60320;
 	static const int keyBlind = 0x60321;
 	static const int keyGo = 0x60322;
+	static const int keyGoBack = 0x60323;
+
 
 	static const int key1 = 0x60401;
 	static const int key2 = 0x60402;
@@ -281,6 +283,10 @@ void MainContentComponent::getCommandInfo(CommandID commandID, ApplicationComman
 		result.setInfo("Go main cuelist", "", "Direct Commands", 0);
 		result.addDefaultKeypress(KeyPress::createFromDescription(" ").getKeyCode(), ModifierKeys::noModifiers);
 		break;
+	case BlinderKittenCommandId::keyGoBack:
+		result.setInfo("Go back main cuelist", "", "Direct Commands", 0);
+		result.addDefaultKeypress(KeyPress::createFromDescription(" ").getKeyCode(), ModifierKeys::shiftModifier);
+		break;
 
 
 
@@ -407,6 +413,7 @@ void MainContentComponent::getAllCommands(Array<CommandID>& commands) {
 		BlinderKittenCommandId::keyHighlight,
 		BlinderKittenCommandId::keyBlind,
 		BlinderKittenCommandId::keyGo,
+		BlinderKittenCommandId::keyGoBack,
 
 		BlinderKittenCommandId::key1,
 		BlinderKittenCommandId::key2,
@@ -563,6 +570,7 @@ bool MainContentComponent::perform(const InvocationInfo& info)
 	case BlinderKittenCommandId::keyHighlight: {UserInputManager::getInstance()->toggleHightlight(); }break;
 	case BlinderKittenCommandId::keyBlind: { UserInputManager::getInstance()->toggleBlind(); }break;
 	case BlinderKittenCommandId::keyGo: { UserInputManager::getInstance()->goMainCuelist(); }break;
+	case BlinderKittenCommandId::keyGoBack: { UserInputManager::getInstance()->goBackMainCuelist(); }break;
 
 	case BlinderKittenCommandId::keyClear: {	UserInputManager::getInstance()->processInput("Clear"); }break;
 	case BlinderKittenCommandId::keyBackspace: {UserInputManager::getInstance()->processInput("Backspace"); }break;

--- a/Source/UserInputManager.cpp
+++ b/Source/UserInputManager.cpp
@@ -812,6 +812,15 @@ void UserInputManager::goMainCuelist()
 	target->userGo();
 }
 
+void UserInputManager::goBackMainCuelist()
+{
+	BKEngine* engine = (BKEngine*) Engine::mainEngine;
+	int targetCueId = engine->conductorCuelistId->intValue();
+	Cuelist* target = Brain::getInstance()->getCuelistById(targetCueId);
+	if (target == nullptr) return;
+	target->goBack();
+}
+
 String UserInputManager::toUserText(String s) {
 	if (s.containsOnly("1234567890.")) {return s;}
 	if (s == "group") { return "Group"; }

--- a/Source/UserInputManager.h
+++ b/Source/UserInputManager.h
@@ -56,6 +56,7 @@ public:
     void toggleBlind();
 
     void goMainCuelist();
+    void goBackMainCuelist();
 
     String toUserText(String s);
     Programmer* getProgrammer(bool createIfNotThere);


### PR DESCRIPTION
Adding a simple keybind for main cuelist go back that I was missing.

In general, it would be great to be able to add a keybind to Virtual Buttons (and Virtual Faders?) so users can create custom keyboard commands using that action engine (like in QLC+). However, I took a quick look, and that seems to be much more complicated than I expected in JUCE. May revisit in a future PR

Cheers!