### PR TITLE
Fix channel snap not being respected in cue off

### DIFF
--- a/Source/Definitions/Cuelist/Cuelist.cpp
+++ b/Source/Definitions/Cuelist/Cuelist.cpp
@@ -766,6 +766,10 @@ void Cuelist::go(Cue* c, float forcedDelay, float forcedFade) {
 					}
 				}
 
+				if (it.getKey()->snapOnly) {
+					fadeTime = 0;
+				}
+
 				float delay = forcedDelay != -1 ? forcedDelay : delayTime;
 				float fade = forcedFade != -1 ? forcedFade : fadeTime;
 				delay *= speedMultVal;


### PR DESCRIPTION
Quick fix for what seems to be an oversight: cues seem to respect `Snap` channels when turning on, but fade them out when turning the cue off (either going to next cue or cuelist off commands)

1. Create a Fixture with one or more channels that have `Fade or snap` set to `Snap` in the fixture type
2. Create a cuelist with the fixture and have one of the cues modify the snap channels
3. "Go" or "Off" on the cuelist

**Expected outcome**: The cue off respects `Snap` and immediately turns those channels to the default values
**Currently observed outcome**: The cue fades the `Snap` channels along with others

Note that this adjustment will still allow snap channels to be faded via forcedFade, as I assumed that was desirable

Cheers!