### PR TITLE
Add support for DMXKing multi-output USB adapters

### DIFF
--- a/BlinderKitten.jucer
+++ b/BlinderKitten.jucer
@@ -195,6 +195,14 @@
                   file="Source/Common/DMX/device/DMXEnttecProDevice.cpp"/>
             <FILE id="QS0L0n" name="DMXEnttecProDevice.h" compile="0" resource="0"
                   file="Source/Common/DMX/device/DMXEnttecProDevice.h"/>
+            <FILE id="DMXKng1" name="DMXKingDevice.cpp" compile="0" resource="0"
+                  file="Source/Common/DMX/device/DMXKingDevice.cpp"/>
+            <FILE id="DMXKng2" name="DMXKingDevice.h" compile="0" resource="0"
+                  file="Source/Common/DMX/device/DMXKingDevice.h"/>
+            <FILE id="DMXKngM1" name="DMXKingManager.cpp" compile="0" resource="0"
+                  file="Source/Common/DMX/device/DMXKingManager.cpp"/>
+            <FILE id="DMXKngM2" name="DMXKingManager.h" compile="0" resource="0"
+                  file="Source/Common/DMX/device/DMXKingManager.h"/>
             <FILE id="lNcEcE" name="DMXEuroliteDevice.cpp" compile="0" resource="0"
                   file="Source/Common/DMX/device/DMXEuroliteDevice.cpp"/>
             <FILE id="eEhRpL" name="DMXEuroliteDevice.h" compile="0" resource="0"

--- a/Builds/MacOSX_CI/BlinderKitten.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX_CI/BlinderKitten.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		17A28BCED9670E9D92D58781 /* DMXArtNetDevice.cpp */ /* DMXArtNetDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DMXArtNetDevice.cpp; path = ../../Source/Common/DMX/device/DMXArtNetDevice.cpp; sourceTree = SOURCE_ROOT; };
 		17CD59F07AAF0B1D28008686 /* InterfaceAction.cpp */ /* InterfaceAction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = InterfaceAction.cpp; path = ../../Source/Definitions/Actions/InterfaceAction.cpp; sourceTree = SOURCE_ROOT; };
 		181A07662AAC881A0B6981AA /* FixtureGridView.cpp */ /* FixtureGridView.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FixtureGridView.cpp; path = ../../Source/UI/GridView/FixtureGridView.cpp; sourceTree = SOURCE_ROOT; };
+		1855D745B46C82FADB7C69A8 /* DMXKingManager.cpp */ /* DMXKingManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DMXKingManager.cpp; path = ../../Source/Common/DMX/device/DMXKingManager.cpp; sourceTree = SOURCE_ROOT; };
 		1865B24A35045C21873DF897 /* ChannelFamilyManager.h */ /* ChannelFamilyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelFamilyManager.h; path = ../../Source/Definitions/ChannelFamily/ChannelFamilyManager.h; sourceTree = SOURCE_ROOT; };
 		197ECD317D224A16CC530D7B /* InputPanelAction.cpp */ /* InputPanelAction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = InputPanelAction.cpp; path = ../../Source/Definitions/Actions/InputPanelAction.cpp; sourceTree = SOURCE_ROOT; };
 		19CD88406B5F91BA01EB2F7B /* MIDIMappingEditor.h */ /* MIDIMappingEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIDIMappingEditor.h; path = ../../Source/Definitions/Interface/interfaces/midi/ui/MIDIMappingEditor.h; sourceTree = SOURCE_ROOT; };
@@ -383,6 +384,7 @@
 		580A7738712B044BC5D57AED /* FixtureType.cpp */ /* FixtureType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FixtureType.cpp; path = ../../Source/Definitions/FixtureType/FixtureType.cpp; sourceTree = SOURCE_ROOT; };
 		5902880D8C6266E7A543E631 /* include_juce_organicui4.cpp */ /* include_juce_organicui4.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = include_juce_organicui4.cpp; path = ../../JuceLibraryCode/include_juce_organicui4.cpp; sourceTree = SOURCE_ROOT; };
 		5941FA6A90768BF9A5502B6B /* CommandSelectionManager.cpp */ /* CommandSelectionManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CommandSelectionManager.cpp; path = ../../Source/Definitions/Command/CommandSelectionManager.cpp; sourceTree = SOURCE_ROOT; };
+		5980950E7C53438B39E1E3DC /* DMXKingDevice.cpp */ /* DMXKingDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DMXKingDevice.cpp; path = ../../Source/Common/DMX/device/DMXKingDevice.cpp; sourceTree = SOURCE_ROOT; };
 		5994718CBE5FBFFB7CE9D8ED /* BundleAction.h */ /* BundleAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BundleAction.h; path = ../../Source/Definitions/Actions/BundleAction.h; sourceTree = SOURCE_ROOT; };
 		5AAD17CFD29D80557F9F840E /* Programmer.h */ /* Programmer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Programmer.h; path = ../../Source/Definitions/Programmer/Programmer.h; sourceTree = SOURCE_ROOT; };
 		5ABAC0BB0FF1C7D8D4D668A6 /* MapperAction.h */ /* MapperAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MapperAction.h; path = ../../Source/Definitions/Actions/MapperAction.h; sourceTree = SOURCE_ROOT; };
@@ -578,6 +580,7 @@
 		C2BCDF4037840E45BA3E7E08 /* VirtualFaderColManagerUI.h */ /* VirtualFaderColManagerUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VirtualFaderColManagerUI.h; path = ../../Source/UI/VirtualFaders/VirtualFaderColManagerUI.h; sourceTree = SOURCE_ROOT; };
 		C341F4837AA231F0D1F5AB62 /* colorpicker.png */ /* colorpicker.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = colorpicker.png; path = ../../Ressources/colorpicker.png; sourceTree = SOURCE_ROOT; };
 		C367855733BE23EFCB64EA4E /* BinaryData.cpp */ /* BinaryData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryData.cpp; path = ../../JuceLibraryCode/BinaryData.cpp; sourceTree = SOURCE_ROOT; };
+		C38E4152867860612D46197C /* DMXKingDevice.h */ /* DMXKingDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DMXKingDevice.h; path = ../../Source/Common/DMX/device/DMXKingDevice.h; sourceTree = SOURCE_ROOT; };
 		C3DEA777296931874600C0E8 /* FixtureMapping.h */ /* FixtureMapping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FixtureMapping.h; path = ../../Source/Definitions/Fixture/FixtureMapping.h; sourceTree = SOURCE_ROOT; };
 		C3F4E0B7220A005B961C1F49 /* TrackerManager.cpp */ /* TrackerManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TrackerManager.cpp; path = ../../Source/Definitions/Tracker/TrackerManager.cpp; sourceTree = SOURCE_ROOT; };
 		C6DEAF58E7E2C03A08D4EC20 /* VirtualFaderColManager.cpp */ /* VirtualFaderColManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = VirtualFaderColManager.cpp; path = ../../Source/UI/VirtualFaders/VirtualFaderColManager.cpp; sourceTree = SOURCE_ROOT; };
@@ -661,6 +664,7 @@
 		EA83A967D6F2B7C960B23AE6 /* TrackerManagerUI.h */ /* TrackerManagerUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TrackerManagerUI.h; path = ../../Source/Definitions/Tracker/TrackerManagerUI.h; sourceTree = SOURCE_ROOT; };
 		EABF4249A8BE72CFCB047C98 /* BundleSelection.h */ /* BundleSelection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BundleSelection.h; path = ../../Source/Definitions/Bundle/BundleSelection.h; sourceTree = SOURCE_ROOT; };
 		EAC12D832E2F8B97C382CCF9 /* OSCMapping.h */ /* OSCMapping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OSCMapping.h; path = ../../Source/Definitions/Interface/interfaces/osc/OSCMapping.h; sourceTree = SOURCE_ROOT; };
+		EBA9BEBCBB8CBB6285BC2F5C /* DMXKingManager.h */ /* DMXKingManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DMXKingManager.h; path = ../../Source/Common/DMX/device/DMXKingManager.h; sourceTree = SOURCE_ROOT; };
 		EBD6D22055646F12F15B281D /* InterfaceManagerUI.h */ /* InterfaceManagerUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = InterfaceManagerUI.h; path = ../../Source/Definitions/Interface/ui/InterfaceManagerUI.h; sourceTree = SOURCE_ROOT; };
 		ED6A0B82F8048D94BFA8D889 /* EffectAction.cpp */ /* EffectAction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EffectAction.cpp; path = ../../Source/Definitions/Actions/EffectAction.cpp; sourceTree = SOURCE_ROOT; };
 		EDF255073E203504EC2B2D00 /* Security.framework */ /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -1589,6 +1593,10 @@
 				4FE6612BB9154E6643987C60,
 				1F4A84A1AF9CDB48E3E47DEC,
 				0035ABB06ECA7EDCAB496C6A,
+				5980950E7C53438B39E1E3DC,
+				C38E4152867860612D46197C,
+				1855D745B46C82FADB7C69A8,
+				EBA9BEBCBB8CBB6285BC2F5C,
 				3CBA8F4337A7E507D8D40C07,
 				49482E859F6AF960EF1DEFB4,
 				014EDAA820EA34A7242D76BE,

--- a/Builds/VisualStudio2019/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2019/BlinderKitten_App.vcxproj
@@ -211,6 +211,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3518,6 +3524,8 @@
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXArtNetDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXOpenUSBDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXSACNDevice.h"/>

--- a/Builds/VisualStudio2019/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2019/BlinderKitten_App.vcxproj.filters
@@ -1273,6 +1273,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
@@ -5149,6 +5155,12 @@
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h">

--- a/Builds/VisualStudio2022/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2022/BlinderKitten_App.vcxproj
@@ -214,6 +214,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3521,6 +3527,8 @@
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXArtNetDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXOpenUSBDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXSACNDevice.h"/>

--- a/Builds/VisualStudio2022/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2022/BlinderKitten_App.vcxproj.filters
@@ -1273,6 +1273,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
@@ -5149,6 +5155,12 @@
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h">

--- a/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj
@@ -212,6 +212,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3519,6 +3525,8 @@
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXArtNetDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXOpenUSBDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXSACNDevice.h"/>

--- a/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj.filters
@@ -1273,6 +1273,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
@@ -5149,6 +5155,12 @@
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h">

--- a/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj
@@ -215,6 +215,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3522,6 +3528,8 @@
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXArtNetDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h"/>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXOpenUSBDevice.h"/>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXSACNDevice.h"/>

--- a/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj.filters
@@ -1273,6 +1273,12 @@
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingDevice.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\Common\DMX\device\DMXKingManager.cpp">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.cpp">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClCompile>
@@ -5149,6 +5155,12 @@
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEnttecProDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingDevice.h">
+      <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\Common\DMX\device\DMXKingManager.h">
       <Filter>BlinderKitten\Source\Common\DMX\device</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Common\DMX\device\DMXEuroliteDevice.h">

--- a/Source/Common/CommonIncludes.cpp
+++ b/Source/Common/CommonIncludes.cpp
@@ -30,6 +30,8 @@
 #include "DMX/device/DMXSerialDevice.cpp"
 #include "DMX/device/DMXArtNetDevice.cpp"
 #include "DMX/device/DMXEnttecProDevice.cpp"
+#include "DMX/device/DMXKingManager.cpp"
+#include "DMX/device/DMXKingDevice.cpp"
 #include "DMX/device/DMXOpenUSBDevice.cpp"
 #include "DMX/device/DMXEuroliteDevice.cpp"
 #include "DMX/device/DMXSACNDevice.cpp"

--- a/Source/Common/CommonIncludes.h
+++ b/Source/Common/CommonIncludes.h
@@ -34,6 +34,8 @@
 #include "DMX/device/DMXOpenUSBDevice.h"
 #include "DMX/device/DMXEuroliteDevice.h"
 #include "DMX/device/DMXSACNDevice.h"
+#include "DMX/device/DMXKingManager.h"
+#include "DMX/device/DMXKingDevice.h"
 
 #include "Helpers/SceneHelpers.h"
 

--- a/Source/Common/DMX/device/DMXDevice.cpp
+++ b/Source/Common/DMX/device/DMXDevice.cpp
@@ -136,6 +136,10 @@ DMXDevice* DMXDevice::create(Type type)
 		return new DMXSACNDevice();
 		break;
 
+	case DMXKING:
+		return new DMXKingDevice();
+		break;
+
 	default:
 		DBG("Not handled");
 		break;

--- a/Source/Common/DMX/device/DMXDevice.h
+++ b/Source/Common/DMX/device/DMXDevice.h
@@ -15,7 +15,7 @@ class DMXDevice :
 	public Thread
 {
 public:
-	enum Type { OPENDMX, ENTTEC_DMXPRO, ENTTEC_MK2, ARTNET, EUROLITE, SACN };
+	enum Type { OPENDMX, ENTTEC_DMXPRO, ENTTEC_MK2, ARTNET, EUROLITE, SACN, DMXKING };
 	DMXDevice(const String &name, Type type, bool canReceive);
 	virtual ~DMXDevice();
 

--- a/Source/Common/DMX/device/DMXKingDevice.cpp
+++ b/Source/Common/DMX/device/DMXKingDevice.cpp
@@ -16,10 +16,10 @@ DMXKingDevice::DMXKingDevice() :
 {
 	inputCC->enabled->setValue(false);
 
-	// Start with just Port 1, will be updated when device capabilities are detected
+	// Start with just Port A, will be updated when device capabilities are detected
 	outputPort = outputCC->addEnumParameter("Output Port", "Select which physical output port to use");
-	outputPort->addOption("Port 1", 1);
-	outputPort->setValueWithKey("Port 1");
+	outputPort->addOption("Port A", 1);
+	outputPort->setValueWithKey("Port A");
 }
 
 DMXKingDevice::~DMXKingDevice()
@@ -96,13 +96,14 @@ void DMXKingDevice::onPortCountDetected(int portCount)
 
 	for (int i = 1; i <= portCount; ++i)
 	{
-		outputPort->addOption("Port " + String(i), i);
+		char portLetter = 'A' + (i - 1);
+		outputPort->addOption("Port " + String::charToString(portLetter), i);
 	}
 
 	int currentPort = getCurrentOutputPortNumber();
 	if (currentPort > portCount)
 	{
-		outputPort->setValueWithKey("Port 1");
+		outputPort->setValueWithKey("Port A");
 	}
 }
 

--- a/Source/Common/DMX/device/DMXKingDevice.cpp
+++ b/Source/Common/DMX/device/DMXKingDevice.cpp
@@ -1,0 +1,120 @@
+/*
+  ==============================================================================
+
+	DMXKingDevice.cpp
+	Created: 25 Sep 2025
+	Author:  j-mutter
+
+  ==============================================================================
+*/
+
+#include "DMXKingDevice.h"
+#include "DMXKingManager.h"
+
+DMXKingDevice::DMXKingDevice() :
+	DMXSerialDevice("DMXKing eDMX PRO", DMXKING, true)
+{
+	inputCC->enabled->setValue(false);
+
+	// Add port selection parameter
+	outputPort = outputCC->addEnumParameter("Output Port", "Select which physical output port to use");
+	outputPort->addOption("Port 1", 1);
+	outputPort->addOption("Port 2", 2);
+	outputPort->addOption("Port 3", 3);
+	outputPort->addOption("Port 4", 4);
+	outputPort->addOption("Port 5", 5);
+	outputPort->addOption("Port 6", 6);
+	outputPort->addOption("Port 7", 7);
+	outputPort->addOption("Port 8", 8);
+	outputPort->setValue(1); // Default to Port 1
+}
+
+DMXKingDevice::~DMXKingDevice()
+{
+	if (DMXKingManager::getInstanceWithoutCreating())
+	{
+		DMXKingManager::getInstance()->unregisterDevice(this);
+	}
+}
+
+int DMXKingDevice::getCurrentPortNumber() const
+{
+	return outputPort->getValueData();
+}
+
+void DMXKingDevice::setCurrentPort(SerialDevice * port)
+{
+	// Unregister from old hardware if switching
+	if (DMXKingManager::getInstanceWithoutCreating() && dmxPort && sharedHardwareId.isNotEmpty())
+	{
+		DMXKingManager::getInstance()->unregisterDevice(this);
+	}
+
+	// Call parent implementation
+	DMXSerialDevice::setCurrentPort(port);
+
+	// Register with new shared hardware
+	if (port)
+	{
+		sharedHardwareId = port->info->deviceID;
+		DMXKingManager::getInstance()->registerDevice(this, port);
+	}
+	else
+	{
+		sharedHardwareId = "";
+	}
+}
+
+void DMXKingDevice::setPortConfig()
+{
+	// Port configuration is handled by DMXKingManager for shared hardware
+	// This device doesn't directly configure the port
+}
+
+void DMXKingDevice::sendDMXValuesSerialInternal()
+{
+    // Send data through the shared manager with the selected port
+    int portNumber = getCurrentPortNumber();
+
+	if (!outputCC->enabled->boolValue() || sharedHardwareId.isEmpty() || portNumber < 1 || portNumber > 8)
+		return;
+
+	DMXKingManager::getInstance()->sendDMXData(sharedHardwareId, portNumber, dmxDataOut);
+}
+
+void DMXKingDevice::onSharedHardwareConnected()
+{
+	setConnected(true);
+}
+
+void DMXKingDevice::onSharedHardwareDisconnected()
+{
+	setConnected(false);
+}
+
+void DMXKingDevice::onContainerParameterChanged(Parameter * p)
+{
+	DMXSerialDevice::onContainerParameterChanged(p);
+
+	if (p == portParam)
+	{
+		// Serial port changed - update hardware registration
+		SerialDevice* newPort = portParam->getDevice();
+		setCurrentPort(newPort);
+	}
+	else if (p == outputPort)
+	{
+		// Output port selection changed - update registration if needed
+		updatePortRegistration();
+	}
+}
+
+void DMXKingDevice::updatePortRegistration()
+{
+	// If we're connected to hardware, re-register to update port mapping
+	if (!sharedHardwareId.isEmpty() && dmxPort)
+	{
+		DMXKingManager::getInstance()->unregisterDevice(this);
+		DMXKingManager::getInstance()->registerDevice(this, dmxPort);
+	}
+}

--- a/Source/Common/DMX/device/DMXKingDevice.h
+++ b/Source/Common/DMX/device/DMXKingDevice.h
@@ -21,7 +21,7 @@ public:
 
 	// Port selection parameter
 	EnumParameter* outputPort;
-	int getCurrentPortNumber() const;
+	int getCurrentOutputPortNumber() const;
 
 	// Override DMXSerialDevice methods to use shared hardware
 	void setCurrentPort(SerialDevice * port);
@@ -31,6 +31,9 @@ public:
 	// Called by DMXKingManager when shared hardware connects/disconnects
 	void onSharedHardwareConnected();
 	void onSharedHardwareDisconnected();
+
+	// Called by DMXKingManager when port count is detected
+	void onPortCountDetected(int portCount);
 
 	// Override parameter changes to handle port selection
 	void onContainerParameterChanged(Parameter * p) override;

--- a/Source/Common/DMX/device/DMXKingDevice.h
+++ b/Source/Common/DMX/device/DMXKingDevice.h
@@ -1,0 +1,43 @@
+/*
+  ==============================================================================
+
+    DMXKingDevice.h
+    Created: 25 Sep 2025
+    Author:  j-mutter
+
+  ==============================================================================
+*/
+
+#pragma once
+
+class DMXKingManager;
+
+class DMXKingDevice :
+	public DMXSerialDevice
+{
+public:
+	DMXKingDevice();
+	~DMXKingDevice();
+
+	// Port selection parameter
+	EnumParameter* outputPort;
+	int getCurrentPortNumber() const;
+
+	// Override DMXSerialDevice methods to use shared hardware
+	void setCurrentPort(SerialDevice * port);
+	void setPortConfig() override;
+	void sendDMXValuesSerialInternal() override;
+
+	// Called by DMXKingManager when shared hardware connects/disconnects
+	void onSharedHardwareConnected();
+	void onSharedHardwareDisconnected();
+
+	// Override parameter changes to handle port selection
+	void onContainerParameterChanged(Parameter * p) override;
+
+private:
+	String sharedHardwareId;
+	void updatePortRegistration();
+
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DMXKingDevice)
+};

--- a/Source/Common/DMX/device/DMXKingManager.cpp
+++ b/Source/Common/DMX/device/DMXKingManager.cpp
@@ -1,0 +1,329 @@
+/*
+  ==============================================================================
+
+    DMXKingManager.cpp
+    Created: 26 Sep 2025
+    Author:  j-mutter
+
+  ==============================================================================
+*/
+
+#include "DMXKingManager.h"
+#include "DMXKingDevice.h"
+
+juce_ImplementSingleton(DMXKingManager)
+
+DMXKingManager::DMXKingManager()
+{
+}
+
+DMXKingManager::~DMXKingManager()
+{
+    HashMap<String, SharedHardware*>::Iterator it(hardwareMap);
+    while (it.next())
+    {
+        SharedHardware* hw = it.getValue();
+        if (hw->serialDevice)
+        {
+            hw->serialDevice->removeSerialDeviceListener(this);
+            hw->serialDevice->close();
+        }
+        delete hw;
+    }
+    hardwareMap.clear();
+}
+
+void DMXKingManager::registerDevice(DMXKingDevice* device, SerialDevice* serialDevice)
+{
+    if (!serialDevice) return;
+
+    String serialPortId = serialDevice->info->deviceID;
+    NLOG("DMXKingManager: ", "registerDevice " + serialPortId);
+
+    SharedHardware* hardware = getOrCreateHardware(serialDevice);
+    hardware->connectedDevices.addIfNotAlreadyThere(device);
+}
+
+void DMXKingManager::unregisterDevice(DMXKingDevice* device)
+{
+    HashMap<String, SharedHardware*>::Iterator it(hardwareMap);
+    while (it.next())
+    {
+        SharedHardware* hw = it.getValue();
+        hw->connectedDevices.removeAllInstancesOf(device);
+
+        // If no devices left, clean up hardware
+        if (hw->connectedDevices.isEmpty())
+        {
+            if (hw->serialDevice)
+            {
+                hw->serialDevice->removeSerialDeviceListener(this);
+                hw->serialDevice->close();
+            }
+            String key = it.getKey();
+            delete hw;
+            hardwareMap.remove(key);
+            break;
+        }
+    }
+}
+
+DMXKingManager::SharedHardware* DMXKingManager::getOrCreateHardware(SerialDevice* serialDevice)
+{
+    String serialPortId = serialDevice->info->deviceID;
+
+    if (!hardwareMap.contains(serialPortId))
+    {
+        SharedHardware* hardware = new SharedHardware();
+        hardware->deviceID = serialPortId;
+        hardware->serialDevice = serialDevice;
+
+        // Set up serial device listener
+        serialDevice->addSerialDeviceListener(this);
+
+        // Configure port if it's open
+        if (serialDevice->isOpen())
+        {
+            setSerialConfig(hardware);
+        }
+
+        NLOG("DMXKingManager: ", "Created new SharedHardware for " + serialPortId);
+        hardwareMap.set(serialPortId, hardware);
+    }
+    else
+    {
+        // Make sure the hardware has the correct serial device reference
+        SharedHardware* hardware = hardwareMap[serialPortId];
+        if (hardware->serialDevice != serialDevice)
+        {
+            // Remove listener from old device if it exists
+            if (hardware->serialDevice)
+            {
+                hardware->serialDevice->removeSerialDeviceListener(this);
+            }
+
+            // Update to new device
+            hardware->serialDevice = serialDevice;
+            serialDevice->addSerialDeviceListener(this);
+
+            // Configure port if it's open
+            if (serialDevice->isOpen())
+            {
+                setSerialConfig(hardware);
+            }
+        }
+        NLOG("DMXKingManager: ", "Updated SharedHardware for " + serialPortId);
+    }
+
+    return hardwareMap[serialPortId];
+}
+
+void DMXKingManager::sendDMXData(const String& serialPortId, int outputPort, const uint8* data)
+{
+    SharedHardware* hardware = hardwareMap[serialPortId];
+    if (!hardware || !hardware->serialDevice || !hardware->serialDevice->isOpen())
+        return;
+
+    try
+    {
+        // Determine port label based on port number (1-8)
+        uint8 outputPortLabel = DMXKING_SEND_PORT1_LABEL + (outputPort - 1);
+
+        uint8 headerData[5] = {
+            DMXKING_START_MESSAGE,
+            outputPortLabel,
+            (DMXKING_CHANNEL_COUNT + 1) & 255,
+            ((DMXKING_CHANNEL_COUNT + 1) >> 8) & 255,
+            DMXKING_START_CODE
+        };
+
+        uint8 footerData[1] = { DMXKING_END_MESSAGE };
+
+        NLOG("DMXKingManager: ", "Sending DMX data to port " + String(outputPort) + " (label 0x" + String::toHexString(outputPortLabel) + ")");
+
+        hardware->serialDevice->port->write(headerData, 5);
+        hardware->serialDevice->port->write(data, 512);
+        hardware->serialDevice->port->write(footerData, 1);
+        hardware->serialDevice->port->flush();
+    }
+    catch (serial::IOException e)
+    {
+        DBG("IO Exception on DMXKing port " << serialPortId << ": " << e.what());
+    }
+    catch (serial::PortNotOpenedException)
+    {
+        DBG("Port Not Opened on DMXKing port " << serialPortId);
+    }
+    catch (serial::SerialException e)
+    {
+        DBG("Serial Exception on DMXKing port " << serialPortId << ": " << e.what());
+    }
+}
+
+void DMXKingManager::setSerialConfig(SharedHardware* hardware)
+{
+    if (!hardware->serialDevice) return;
+
+    hardware->serialDevice->port->setBaudrate(115200);
+    hardware->serialDevice->port->setBytesize(serial::eightbits);
+    hardware->serialDevice->port->setStopbits(serial::stopbits_one);
+    hardware->serialDevice->port->setParity(serial::parity_none);
+    hardware->serialDevice->port->flush();
+
+    // Get serial number
+    Array<uint8> getSerialNumberBytes((uint8)0x7E, (uint8)10, (uint8)0, (uint8)0, (uint8)0xE7);
+    hardware->serialDevice->writeBytes(getSerialNumberBytes);
+
+    // Enable change-on-data mode
+    uint8 changeAlwaysData[6] = { DMXKING_START_MESSAGE, DMXKING_RECEIVE_ON_CHANGE_LABEL, 1, 0, DMXKING_CHANGE_ALWAYS_CODE, DMXKING_END_MESSAGE };
+    hardware->serialDevice->port->write(changeAlwaysData, 6);
+}
+
+void DMXKingManager::serialDataReceived(const var& data)
+{
+    // Find which hardware this data belongs to
+    SerialDevice* sender = dynamic_cast<SerialDevice*>(data.getObject());
+    if (!sender) return;
+
+    SharedHardware* hardware = nullptr;
+    HashMap<String, SharedHardware*>::Iterator it(hardwareMap);
+    while (it.next())
+    {
+        SharedHardware* hw = it.getValue();
+        if (hw->serialDevice == sender)
+        {
+            hardware = hw;
+            break;
+        }
+    }
+
+    if (!hardware) return;
+
+    hardware->serialBuffer.addArray((const uint8_t*)data.getBinaryData()->getData(), (int)data.getBinaryData()->getSize());
+
+    int endIndex = 0;
+    Array<uint8> packet = getDMXPacket(hardware->serialBuffer, endIndex);
+    while (packet.size() > 0)
+    {
+        processDMXPacket(hardware, packet);
+        hardware->serialBuffer.removeRange(0, endIndex);
+        packet = getDMXPacket(hardware->serialBuffer, endIndex);
+    }
+}
+
+void DMXKingManager::portOpened(SerialDevice* port)
+{
+    HashMap<String, SharedHardware*>::Iterator it(hardwareMap);
+    while (it.next())
+    {
+        SharedHardware* hw = it.getValue();
+        if (hw->serialDevice == port)
+        {
+            setSerialConfig(hw);
+
+            // Notify all connected devices
+            for (auto device : hw->connectedDevices)
+            {
+                device->onSharedHardwareConnected();
+            }
+            break;
+        }
+    }
+}
+
+void DMXKingManager::portClosed(SerialDevice* port)
+{
+    HashMap<String, SharedHardware*>::Iterator it(hardwareMap);
+    while (it.next())
+    {
+        SharedHardware* hw = it.getValue();
+        if (hw->serialDevice == port)
+        {
+            // Notify all connected devices
+            for (auto device : hw->connectedDevices)
+            {
+                device->onSharedHardwareDisconnected();
+            }
+            break;
+        }
+    }
+}
+
+void DMXKingManager::portRemoved(SerialDevice* port)
+{
+    portClosed(port);
+}
+
+Array<uint8> DMXKingManager::getDMXPacket(Array<uint8> bytes, int& endIndex)
+{
+    if (bytes.size() < DMXKING_HEADER_LENGTH + 1) return Array<uint8>();
+    int numBytes = bytes.size();
+
+    for (int i = 0; i < numBytes; ++i)
+    {
+        if (bytes[i] == DMXKING_START_MESSAGE)
+        {
+            int length = (int)bytes[i + 2] + ((int)bytes[i + 3] << 8);
+            if (bytes.size() - i < DMXKING_HEADER_LENGTH + length) continue;
+            endIndex = i + DMXKING_HEADER_LENGTH + length;
+
+            if (bytes[endIndex] == DMXKING_END_MESSAGE)
+            {
+                return Array<uint8>(bytes.getRawDataPointer() + i, DMXKING_HEADER_LENGTH + length);
+            }
+        }
+    }
+
+    return Array<uint8>();
+}
+
+void DMXKingManager::processDMXPacket(SharedHardware* hardware, Array<uint8> bytes)
+{
+    int messageLabel = (int)bytes[1];
+    int length = (int)bytes[2] + ((int)bytes[3] << 8);
+
+    switch (messageLabel)
+    {
+    case DMXKING_RECEIVE_LABEL:
+    {
+        // Forward to all input-enabled devices
+        if (length > DMXKING_CHANNEL_COUNT + 2)
+        {
+            LOGWARNING("DMXKing bad DMX Length : " << length);
+            return;
+        }
+
+        if (length > bytes.size())
+        {
+            LOGWARNING("DMXKing bad data size : " << bytes.size() << " <> " << length);
+            return;
+        }
+
+        if (bytes[DMXKING_HEADER_LENGTH] != DMXKING_START_CODE)
+        {
+            LOGWARNING("DMXKing bad first byte " << bytes[0] << " should be " << DMXKING_START_CODE);
+            return;
+        }
+
+        for (auto device : hardware->connectedDevices)
+        {
+            if (device->inputCC && device->inputCC->enabled->boolValue())
+            {
+                device->setDMXValuesIn(length - 1, bytes.getRawDataPointer() + DMXKING_HEADER_LENGTH + 1);
+            }
+        }
+    }
+    break;
+
+    case DMXKING_RECEIVE_SERIAL_NUMBER_LABEL:
+    {
+        int serialNumber = (int)(bytes[4] + (bytes[5] << 8) + (bytes[6] << 16) + (bytes[7] << 24));
+        LOG("DMXKing serial number (" << length << ") : " << String::toHexString(serialNumber));
+    }
+    break;
+
+    default:
+        // Handle other messages if needed
+        break;
+    }
+}

--- a/Source/Common/DMX/device/DMXKingManager.h
+++ b/Source/Common/DMX/device/DMXKingManager.h
@@ -1,0 +1,77 @@
+/*
+  ==============================================================================
+
+    DMXKingManager.h
+    Created: 26 Sep 2025
+    Author:  j-mutter
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#define DMXKING_START_MESSAGE 0x7E
+#define DMXKING_END_MESSAGE 0xE7
+
+#define DMXKING_SEND_PORT1_LABEL 0x64
+#define DMXKING_SEND_PORT2_LABEL 0x65
+#define DMXKING_SEND_PORT3_LABEL 0x66
+#define DMXKING_SEND_PORT4_LABEL 0x67
+#define DMXKING_SEND_PORT5_LABEL 0x68
+#define DMXKING_SEND_PORT6_LABEL 0x69
+#define DMXKING_SEND_PORT7_LABEL 0x6A
+#define DMXKING_SEND_PORT8_LABEL 0x6B
+
+#define DMXKING_RECEIVE_LABEL 5
+#define DMXKING_RECEIVE_ON_CHANGE_LABEL 8
+#define DMXKING_RECEIVE_SERIAL_NUMBER_LABEL 10
+
+#define DMXKING_START_CODE 0
+#define DMXKING_CHANNEL_COUNT 512
+
+#define DMXKING_CHANGE_ALWAYS_CODE 0
+#define DMXKING_HEADER_LENGTH 4
+
+class DMXKingDevice;
+
+class DMXKingManager :
+    public SerialDevice::SerialDeviceListener
+{
+public:
+    juce_DeclareSingleton(DMXKingManager, true)
+    DMXKingManager();
+    ~DMXKingManager();
+
+    struct SharedHardware
+    {
+        SerialDevice* serialDevice;
+        String deviceID;
+        Array<DMXKingDevice*> connectedDevices;
+        Array<uint8> serialBuffer;
+
+        SharedHardware() : serialDevice(nullptr) {}
+    };
+
+    HashMap<String, SharedHardware*> hardwareMap;
+
+    // Register/unregister devices for a specific serial port
+    void registerDevice(DMXKingDevice* device, SerialDevice* serialDevice);
+    void unregisterDevice(DMXKingDevice* device);
+
+    // Shared serial communication
+    SharedHardware* getOrCreateHardware(SerialDevice* serialDevice);
+    void sendDMXData(const String& serialPortId, int outputPort, const uint8* data);
+    void setSerialConfig(SharedHardware* hardware);
+
+    // SerialDeviceListener implementation
+    void serialDataReceived(const var &data) override;
+    void portOpened(SerialDevice *) override;
+    void portClosed(SerialDevice *) override;
+    void portRemoved(SerialDevice *) override;
+
+private:
+    void processDMXPacket(SharedHardware* hardware, Array<uint8> bytes);
+    Array<uint8> getDMXPacket(Array<uint8> bytes, int &endIndex);
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DMXKingManager)
+};

--- a/Source/Common/DMX/device/DMXKingManager.h
+++ b/Source/Common/DMX/device/DMXKingManager.h
@@ -26,6 +26,9 @@
 #define DMXKING_RECEIVE_ON_CHANGE_LABEL 8
 #define DMXKING_RECEIVE_SERIAL_NUMBER_LABEL 10
 
+#define DMXKING_DMX_PORT_COUNT_LABEL 0x63
+#define DMXKING_DMX_PORT_DIRECTION_LABEL 0x71
+
 #define DMXKING_START_CODE 0
 #define DMXKING_CHANNEL_COUNT 512
 
@@ -49,7 +52,10 @@ public:
         Array<DMXKingDevice*> connectedDevices;
         Array<uint8> serialBuffer;
 
-        SharedHardware() : serialDevice(nullptr) {}
+        int detectedOutputPortCount;
+        bool outputPortCountDetected;
+
+        SharedHardware() : serialDevice(nullptr), detectedOutputPortCount(1), outputPortCountDetected(false) {}
     };
 
     HashMap<String, SharedHardware*> hardwareMap;
@@ -62,6 +68,11 @@ public:
     SharedHardware* getOrCreateHardware(SerialDevice* serialDevice);
     void sendDMXData(const String& serialPortId, int outputPort, const uint8* data);
     void setSerialConfig(SharedHardware* hardware);
+    void pollDeviceCapabilities(SharedHardware* hardware);
+
+    // Ouput Port count detection
+    int getOutputPortCount(const String& serialPortId);
+    void notifyDevicesOutputPortCountChanged(SharedHardware* hardware);
 
     // SerialDeviceListener implementation
     void serialDataReceived(const var &data) override;

--- a/Source/Definitions/Interface/interfaces/dmx/DMXInterface.cpp
+++ b/Source/Definitions/Interface/interfaces/dmx/DMXInterface.cpp
@@ -30,7 +30,7 @@ DMXInterface::DMXInterface() :
 		->addOption("Art-Net", DMXDevice::ARTNET)
 		->addOption("Eurolite USB-DMX512 Pro", DMXDevice::EUROLITE)
 		->addOption("sACN", DMXDevice::SACN)
-        ->addOption("DMX King", DMXDevice::DMXKING);
+        ->addOption("DMXKing", DMXDevice::DMXKING);
 	dmxType->setValueWithKey("Open DMX");
 
 	dmxConnected = addBoolParameter("Connected", "DMX is connected ?", false);

--- a/Source/Definitions/Interface/interfaces/dmx/DMXInterface.cpp
+++ b/Source/Definitions/Interface/interfaces/dmx/DMXInterface.cpp
@@ -29,7 +29,8 @@ DMXInterface::DMXInterface() :
 		->addOption("Enttec DMX MkII", DMXDevice::ENTTEC_MK2)
 		->addOption("Art-Net", DMXDevice::ARTNET)
 		->addOption("Eurolite USB-DMX512 Pro", DMXDevice::EUROLITE)
-		->addOption("sACN", DMXDevice::SACN);
+		->addOption("sACN", DMXDevice::SACN)
+        ->addOption("DMX King", DMXDevice::DMXKING);
 	dmxType->setValueWithKey("Open DMX");
 
 	dmxConnected = addBoolParameter("Connected", "DMX is connected ?", false);


### PR DESCRIPTION
This adds support for [DMXKing devices](https://dmxking.com/artnetsacn/edmx4-max) that support multiple DMX outputs over USB, such as the eDMX2 Max, eDMX4 Max, eDMX8 Max, etc. as inspired by [qlc+'s implementation](https://github.com/mcallegari/qlcplus/blob/master/plugins/dmxusb/src/enttecdmxusbpro.cpp).

The implementation is split into two classes:
  - **DMXKingDevice**: Individual device instances that can be assigned to specific output ports
  - **DMXKingManager**: Singleton manager that handles shared hardware access and port detection

Once an interface is set to the `DMXKing` type, and then a port is selected for the first time, the `DMXKingManager` connects and polls the device for the number of ports it has, and then populates the `Output Port` list which can then be assigned per interface.

The polling does **not** detect if ports are configured as inputs - only outputs are currently supported.

I've tested this with my **eDMX4 Max DIN** and all four outputs work as expected.

Here's how it looks in the UI/logs:

<details>

<summary> **With a single interface connecting for the first time** ⬇️  </summary>

https://github.com/user-attachments/assets/989a6e06-2b0c-4cd1-abc8-ac56ea74426c

</details>

<details>

<summary> **With multiple interfaces using the same output device** ⬇️ </summary>

https://github.com/user-attachments/assets/b93c8c04-1f93-45ae-a308-3cfc7951c30f

</details>