### PR TITLE
Reset mainComponent last in BlinderKittenApplication::initialiseInternal

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -15,7 +15,6 @@ BlinderKittenApplication::BlinderKittenApplication() :
 void BlinderKittenApplication::initialiseInternal(const String &)
 {
 	engine.reset(new BKEngine());
-	if(useWindow) mainComponent.reset(new MainContentComponent());
 
 	//Call after engine init
 	AppUpdater::getInstance()->setURLs("https://blinderkitten.lighting/update.json", "https://blinderkitten.lighting/installs/", "BlinderKitten");
@@ -27,6 +26,7 @@ void BlinderKittenApplication::initialiseInternal(const String &)
 	
 	ShapeShifterManager::getInstance()->setDefaultFileData(BinaryData::default_blinderlayout);
 	ShapeShifterManager::getInstance()->setLayoutInformations("blinderlayout", "BlinderKitten/layouts");
+    if(useWindow) mainComponent.reset(new MainContentComponent());
 }
 
 


### PR DESCRIPTION
This is another assertion that only fails in debug builds and is really annoying because it happens every time the app is launched.

By resetting the `MainContentComponent()` *before* the `ShapeShifterManager` updates the layout info, we end up trying to reregister the `Load Layout` commands with commandIDs that are already taken, but with slightly different names. `Load Layout 1 (empty)` becomes `Load Layout 1 (default)`, etc.

By delaying the MainContentComponent reset until after the `ShapeShifterManager` has loaded the layout info, we don't have this issue.