### PR TITLE
Fix curl dep on gnutls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           sudo apt-get update
           echo "Installing JUCE lib dependencies and extra tools"
-          sudo apt-get install -qyf libcurl3-gnutls libfreetype6-dev libx11-dev libxinerama-dev libxrandr-dev libxcursor-dev libxcomposite-dev mesa-common-dev libasound2-dev freeglut3-dev libcurl4-gnutls-dev libasound2-dev libjack-dev libbluetooth-dev libgtk-3-dev libwebkit2gtk-4.0-dev libsdl2-dev libfuse2 libfuse2 libusb-1.0-0-dev libhidapi-dev ladspa-sdk libssl-dev
+          sudo apt-get install -qyf libfreetype6-dev libx11-dev libxinerama-dev libxrandr-dev libxcursor-dev libxcomposite-dev mesa-common-dev libasound2-dev freeglut3-dev libcurl4-openssl-dev libasound2-dev libjack-dev libbluetooth-dev libgtk-3-dev libwebkit2gtk-4.0-dev libsdl2-dev libfuse2 libfuse2 libusb-1.0-0-dev libhidapi-dev ladspa-sdk libssl-dev
           sudo apt-get install -qy curl
 
           cd ${{ github.workspace }}


### PR DESCRIPTION
> gnutls is a slightly more obscure library than openssl; this isn't a problem in and of itself, but the build for portable AppImage files still ships with a dependency on this library--and it isn't integrated into the AppImage squashfs. Linking against the (more popular) OpenSSL build of libcurl ought to improve compatibility on various Linux distributions.

Fixes #33.

The changed dep is [automatically picked up by pkg-config](https://github.com/norbertrostaing/BlinderKitten/blob/fedf25a48609e2692cb7453106688a0a068ee316/Builds/LinuxMakefile/Makefile#L69), so no other changes are needed.

Observe a correct build [here](https://github.com/Grissess/BlinderKitten/actions/runs/23629139560/job/68824428175#step:6:235); ignore the overall workflow's failure, that's just because I don't (and shouldn't) have permission to upload the artifacts to your repositories :)