### PR TITLE
Add Timecode Panel

### DIFF
--- a/BlinderKitten.jucer
+++ b/BlinderKitten.jucer
@@ -132,6 +132,10 @@
         <FILE id="wbgqAn" name="BKColorPicker.h" compile="0" resource="0" file="Source/UI/BKColorPicker.h"/>
         <FILE id="AAvC3T" name="Clock.cpp" compile="1" resource="0" file="Source/UI/Clock.cpp"/>
         <FILE id="NIOemw" name="Clock.h" compile="0" resource="0" file="Source/UI/Clock.h"/>
+        <FILE id="Tcv001" name="TimecodeView.cpp" compile="1" resource="0"
+              file="Source/UI/TimecodeView.cpp"/>
+        <FILE id="Tcv002" name="TimecodeView.h" compile="0" resource="0"
+              file="Source/UI/TimecodeView.h"/>
         <FILE id="datAZp" name="ConductorInfos.cpp" compile="1" resource="0"
               file="Source/UI/ConductorInfos.cpp"/>
         <FILE id="mbq0lK" name="ConductorInfos.h" compile="0" resource="0"

--- a/Builds/VisualStudio2019/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2019/BlinderKitten_App.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.cpp"/>
     <ClCompile Include="..\..\Source\UI\BKColorPicker.cpp"/>
     <ClCompile Include="..\..\Source\UI\Clock.cpp"/>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp"/>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp"/>
     <ClCompile Include="..\..\Source\UI\CuelistLoadWindow.cpp"/>
     <ClCompile Include="..\..\Source\UI\DMXChannelView.cpp"/>
@@ -3534,6 +3535,7 @@
     <ClInclude Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.h"/>
     <ClInclude Include="..\..\Source\UI\BKColorPicker.h"/>
     <ClInclude Include="..\..\Source\UI\Clock.h"/>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h"/>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h"/>
     <ClInclude Include="..\..\Source\UI\CuelistLoadWindow.h"/>
     <ClInclude Include="..\..\Source\UI\DMXChannelView.h"/>

--- a/Builds/VisualStudio2019/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2019/BlinderKitten_App.vcxproj.filters
@@ -1237,6 +1237,9 @@
     <ClCompile Include="..\..\Source\UI\Clock.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
@@ -5164,6 +5167,9 @@
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\Clock.h">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h">

--- a/Builds/VisualStudio2022/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2022/BlinderKitten_App.vcxproj
@@ -183,6 +183,7 @@
     <ClCompile Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.cpp"/>
     <ClCompile Include="..\..\Source\UI\BKColorPicker.cpp"/>
     <ClCompile Include="..\..\Source\UI\Clock.cpp"/>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp"/>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp"/>
     <ClCompile Include="..\..\Source\UI\CuelistLoadWindow.cpp"/>
     <ClCompile Include="..\..\Source\UI\DMXChannelView.cpp"/>
@@ -3537,6 +3538,7 @@
     <ClInclude Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.h"/>
     <ClInclude Include="..\..\Source\UI\BKColorPicker.h"/>
     <ClInclude Include="..\..\Source\UI\Clock.h"/>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h"/>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h"/>
     <ClInclude Include="..\..\Source\UI\CuelistLoadWindow.h"/>
     <ClInclude Include="..\..\Source\UI\DMXChannelView.h"/>

--- a/Builds/VisualStudio2022/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2022/BlinderKitten_App.vcxproj.filters
@@ -1237,6 +1237,9 @@
     <ClCompile Include="..\..\Source\UI\Clock.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
@@ -5164,6 +5167,9 @@
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\Clock.h">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h">

--- a/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.cpp"/>
     <ClCompile Include="..\..\Source\UI\BKColorPicker.cpp"/>
     <ClCompile Include="..\..\Source\UI\Clock.cpp"/>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp"/>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp"/>
     <ClCompile Include="..\..\Source\UI\CuelistLoadWindow.cpp"/>
     <ClCompile Include="..\..\Source\UI\DMXChannelView.cpp"/>
@@ -3535,6 +3536,7 @@
     <ClInclude Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.h"/>
     <ClInclude Include="..\..\Source\UI\BKColorPicker.h"/>
     <ClInclude Include="..\..\Source\UI\Clock.h"/>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h"/>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h"/>
     <ClInclude Include="..\..\Source\UI\CuelistLoadWindow.h"/>
     <ClInclude Include="..\..\Source\UI\DMXChannelView.h"/>

--- a/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2022_CI/BlinderKitten_App.vcxproj.filters
@@ -1237,6 +1237,9 @@
     <ClCompile Include="..\..\Source\UI\Clock.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
@@ -5164,6 +5167,9 @@
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\Clock.h">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h">

--- a/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj
+++ b/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.cpp"/>
     <ClCompile Include="..\..\Source\UI\BKColorPicker.cpp"/>
     <ClCompile Include="..\..\Source\UI\Clock.cpp"/>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp"/>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp"/>
     <ClCompile Include="..\..\Source\UI\CuelistLoadWindow.cpp"/>
     <ClCompile Include="..\..\Source\UI\DMXChannelView.cpp"/>
@@ -3538,6 +3539,7 @@
     <ClInclude Include="..\..\Source\UI\VirtualFaders\VirtualFaderSlider.h"/>
     <ClInclude Include="..\..\Source\UI\BKColorPicker.h"/>
     <ClInclude Include="..\..\Source\UI\Clock.h"/>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h"/>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h"/>
     <ClInclude Include="..\..\Source\UI\CuelistLoadWindow.h"/>
     <ClInclude Include="..\..\Source\UI\DMXChannelView.h"/>

--- a/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj.filters
+++ b/Builds/VisualStudio2022_Win7CI/BlinderKitten_App.vcxproj.filters
@@ -1237,6 +1237,9 @@
     <ClCompile Include="..\..\Source\UI\Clock.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\UI\TimecodeView.cpp">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Source\UI\ConductorInfos.cpp">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClCompile>
@@ -5164,6 +5167,9 @@
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\Clock.h">
+      <Filter>BlinderKitten\Source\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Source\UI\TimecodeView.h">
       <Filter>BlinderKitten\Source\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\UI\ConductorInfos.h">

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -47,6 +47,7 @@
 #include "UI/CuelistSheet/CuelistSheet.h"
 #include "UI/PatchSheet/PatchSheet.h"
 #include "UI/Clock.h"
+#include "UI/TimecodeView.h"
 
 //==============================================================================
 MainContentComponent::MainContentComponent()
@@ -159,6 +160,7 @@ void MainContentComponent::init()
     ShapeShifterFactory::getInstance()->defs.add(new ShapeShifterDefinition("Cuelist sheet", &CuelistSheetUI::create));
     ShapeShifterFactory::getInstance()->defs.add(new ShapeShifterDefinition("Patch sheet", &PatchSheetUI::create));
     ShapeShifterFactory::getInstance()->defs.add(new ShapeShifterDefinition("Clock", &ClockUI::create));
+    ShapeShifterFactory::getInstance()->defs.add(new ShapeShifterDefinition("Timecode", &TimecodeViewUI::create));
 
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Interfaces", "Lists");
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Channels config", "Lists");
@@ -202,6 +204,7 @@ void MainContentComponent::init()
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Cuelist sheet", "Panels");
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Patch sheet", "Panels");
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Clock", "Panels");
+    ShapeShifterManager::getInstance()->isInViewSubMenu.set("Timecode", "Panels");
 
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Outliner", "");
     ShapeShifterManager::getInstance()->isInViewSubMenu.set("Dashboard", "Organic Tools");

--- a/Source/UI/TimecodeView.cpp
+++ b/Source/UI/TimecodeView.cpp
@@ -1,0 +1,213 @@
+/*
+  ==============================================================================
+
+    TimecodeView.cpp
+    Created: 5 Jun 2026
+    Author:  BlinderKitten
+
+  ==============================================================================
+*/
+
+#include <JuceHeader.h>
+#include "TimecodeView.h"
+#include "Definitions/Interface/InterfaceIncludes.h"
+
+// Number of timer ticks (at 30 Hz) without a frame change before the source is
+// considered "idle" (~0.5 s).
+static const int idleThresholdTicks = 15;
+
+//==============================================================================
+TimecodeViewUI::TimecodeViewUI(const String& contentName) :
+    ShapeShifterContent(TimecodeView::getInstance(), contentName)
+{
+}
+
+TimecodeViewUI::~TimecodeViewUI()
+{
+}
+
+//==============================================================================
+juce_ImplementSingleton(TimecodeView);
+
+TimecodeView::TimecodeView()
+{
+    sourceSelector.setTextWhenNoChoicesAvailable("No MIDI interface");
+    sourceSelector.addListener(this);
+    addAndMakeVisible(sourceSelector);
+
+    tcLabel.setJustificationType(juce::Justification::centred);
+    tcLabel.setText("--:--:--:--", juce::dontSendNotification);
+    tcLabel.setColour(juce::Label::textColourId, juce::Colours::grey);
+    addAndMakeVisible(tcLabel);
+
+    statusLabel.setJustificationType(juce::Justification::centred);
+    statusLabel.setText("No timecode source", juce::dontSendNotification);
+    statusLabel.setColour(juce::Label::textColourId, juce::Colours::grey);
+    addAndMakeVisible(statusLabel);
+
+    resized();
+    startTimerHz(30);
+}
+
+TimecodeView::~TimecodeView()
+{
+    stopTimer();
+}
+
+void TimecodeView::paint(juce::Graphics&)
+{
+}
+
+void TimecodeView::resized()
+{
+    juce::Rectangle<int> r = getLocalBounds().reduced(2);
+
+    sourceSelector.setBounds(r.removeFromTop(24));
+    statusLabel.setBounds(r.removeFromBottom(18));
+    tcLabel.setBounds(r);
+
+    // Scale the big readout to its area, mirroring Clock::resized().
+    juce::Font f = juce::Font(10, juce::Font::plain);
+    float h = f.getHeight();
+    float w = jmax(1.0f, (float)f.getStringWidth("00:00:00:00"));
+
+    float sizeH = 10 * tcLabel.getHeight() / h;
+    float sizeW = 10 * tcLabel.getWidth() / w;
+    tcLabel.setFont(juce::Font(jmin(sizeW, sizeH), juce::Font::plain));
+
+    statusLabel.setFont(juce::Font(12, juce::Font::plain));
+}
+
+String TimecodeView::framesToString(int tc)
+{
+    // Frame count is stored on a 30 fps baseline (see MIDIInterface), so the
+    // frame field is displayed on that scale regardless of the true source rate.
+    int frame  = tc % 30;
+    int second = (tc / 30) % 60;
+    int minute = (tc / (30 * 60)) % 60;
+    int hour   = tc / (30 * 60 * 60);
+    return juce::String::formatted("%02d:%02d:%02d:%02d", hour, minute, second, frame);
+}
+
+void TimecodeView::rebuildSourceList(const StringArray& names)
+{
+    String prevSel = selectedName;
+
+    sourceSelector.clear(juce::dontSendNotification);
+    sourceSelector.addItem("Auto", 1);
+    int id = 2;
+    for (auto& n : names) sourceSelector.addItem(n, id++);
+
+    currentSourceNames = names;
+
+    if (prevSel.isEmpty() || !names.contains(prevSel))
+    {
+        selectedName = "";
+        sourceSelector.setSelectedId(1, juce::dontSendNotification);
+    }
+    else
+    {
+        sourceSelector.setSelectedId(2 + names.indexOf(prevSel), juce::dontSendNotification);
+    }
+}
+
+void TimecodeView::comboBoxChanged(juce::ComboBox* cb)
+{
+    if (cb != &sourceSelector) return;
+
+    if (sourceSelector.getSelectedId() <= 1) selectedName = "";
+    else selectedName = sourceSelector.getText();
+
+    // force idle tracking to reset on the next tick
+    lastTargetName = "";
+}
+
+void TimecodeView::timerCallback()
+{
+    juce::Array<MIDIInterface*> midiInterfaces = InterfaceManager::getInterfacesOfType<MIDIInterface>();
+
+    // 1. Keep the dropdown in sync with the available interfaces.
+    StringArray names;
+    for (auto* mi : midiInterfaces) names.add(mi->niceName);
+    if (names != currentSourceNames) rebuildSourceList(names);
+
+    // 2. Resolve which interface to display.
+    MIDIInterface* target = nullptr;
+
+    if (selectedName.isNotEmpty())
+    {
+        for (auto* mi : midiInterfaces)
+            if (mi->niceName == selectedName) { target = mi; break; }
+    }
+    else
+    {
+        // Auto : prefer whichever interface's frame changed since last tick.
+        MIDIInterface* changed = nullptr;
+        for (auto* mi : midiInterfaces)
+        {
+            auto it = lastSeenFrame.find(mi->niceName);
+            if (it != lastSeenFrame.end() && it->second != mi->lastFrameSent) changed = mi;
+        }
+
+        if (changed != nullptr)
+        {
+            target = changed;
+            autoActiveName = changed->niceName;
+        }
+        else
+        {
+            // keep the previously active source if it's still around...
+            for (auto* mi : midiInterfaces)
+                if (mi->niceName == autoActiveName) { target = mi; break; }
+
+            // ...otherwise lock onto the first that has produced any timecode.
+            if (target == nullptr)
+                for (auto* mi : midiInterfaces)
+                    if (mi->lastFrameSent >= 0) { target = mi; autoActiveName = mi->niceName; break; }
+        }
+    }
+
+    // remember current frames for next tick's change detection
+    for (auto* mi : midiInterfaces) lastSeenFrame[mi->niceName] = mi->lastFrameSent;
+
+    // 3. Reset idle tracking when the resolved source changes.
+    String targetName = target != nullptr ? target->niceName : String();
+    if (targetName != lastTargetName)
+    {
+        idleTicks = 0;
+        prevFrameForIdle = -1;
+        lastTargetName = targetName;
+    }
+
+    // 4. Render.
+    if (target == nullptr)
+    {
+        tcLabel.setText("--:--:--:--", juce::dontSendNotification);
+        tcLabel.setColour(juce::Label::textColourId, juce::Colours::grey);
+        statusLabel.setText("No timecode source", juce::dontSendNotification);
+        statusLabel.setColour(juce::Label::textColourId, juce::Colours::grey);
+        return;
+    }
+
+    int tc = target->lastFrameSent;
+
+    if (tc < 0)
+    {
+        tcLabel.setText("--:--:--:--", juce::dontSendNotification);
+        tcLabel.setColour(juce::Label::textColourId, juce::Colours::grey);
+        statusLabel.setText(target->niceName + " - waiting", juce::dontSendNotification);
+        statusLabel.setColour(juce::Label::textColourId, juce::Colours::grey);
+        return;
+    }
+
+    if (tc != prevFrameForIdle) { idleTicks = 0; prevFrameForIdle = tc; }
+    else if (idleTicks < 100000) idleTicks++;
+
+    bool running = idleTicks < idleThresholdTicks;
+
+    tcLabel.setText(framesToString(tc), juce::dontSendNotification);
+    tcLabel.setColour(juce::Label::textColourId, running ? juce::Colours::white : juce::Colours::grey);
+
+    statusLabel.setText(target->niceName + (running ? " - running" : " - idle"), juce::dontSendNotification);
+    statusLabel.setColour(juce::Label::textColourId, running ? juce::Colours::white : juce::Colours::grey);
+}

--- a/Source/UI/TimecodeView.h
+++ b/Source/UI/TimecodeView.h
@@ -1,0 +1,67 @@
+/*
+  ==============================================================================
+
+    TimecodeView.h
+    Created: 5 Jun 2026
+    Author:  BlinderKitten
+
+    Panel that displays the live incoming MIDI timecode (HH:MM:SS:FF) with a
+    source selector (defaulting to "Auto") and a running/idle status line.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+#include <map>
+
+//==============================================================================
+class TimecodeViewUI : public ShapeShifterContent
+{
+public:
+    TimecodeViewUI(const String& contentName);
+    ~TimecodeViewUI();
+
+    static TimecodeViewUI* create(const String& name) { return new TimecodeViewUI(name); }
+};
+
+
+class TimecodeView : public juce::Component,
+                     public juce::Timer,
+                     public juce::ComboBox::Listener
+{
+public:
+    juce_DeclareSingleton(TimecodeView, true);
+    TimecodeView();
+    ~TimecodeView() override;
+
+    juce::ComboBox sourceSelector;  // item 1 = "Auto", then one per MIDI interface
+    juce::Label    tcLabel;         // big HH:MM:SS:FF readout
+    juce::Label    statusLabel;     // "<interface name> - running/idle" or "No timecode source"
+
+    void paint(juce::Graphics&) override;
+    void resized() override;
+    void timerCallback() override;
+    void comboBoxChanged(juce::ComboBox*) override;
+
+private:
+    // "" means Auto ; otherwise the niceName of the explicitly selected interface
+    String selectedName;
+    // niceNames currently listed in the dropdown (excluding "Auto"), to detect changes
+    StringArray currentSourceNames;
+    // per-interface last seen lastFrameSent, used by Auto mode to spot the active source
+    std::map<String, int> lastSeenFrame;
+    // interface name Auto mode is currently locked onto
+    String autoActiveName;
+    // name of the target shown last tick (to reset idle tracking on source switch)
+    String lastTargetName;
+
+    int prevFrameForIdle = -1;
+    int idleTicks = 0;
+
+    static String framesToString(int tc);
+    void rebuildSourceList(const StringArray& names);
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TimecodeView)
+};


### PR DESCRIPTION
Adds a dockable "Timecode" panel (View > Panels > Timecode) that displays the
live incoming MIDI timecode as HH:MM:SS:FF, with a source selector (defaulting
to "Auto") and a running/idle status line.

- New TimecodeView panel (ShapeShifterContent wrapper + singleton component),
  mirroring the existing Clock panel pattern. It polls at 30 Hz and reads
  Interface::lastFrameSent from MIDI interfaces, enumerated via
  InterfaceManager::getInterfacesOfType<MIDIInterface>().
- "Auto" mode shows whichever timecode-enabled interface is currently receiving;
  a specific interface can also be picked from the dropdown.
- Registered in MainComponent, the .jucer project, and all VS exporters.

Note: incoming MTC is normalized to a 30 fps baseline upstream in MIDIInterface
(the source fps bits are discarded), so the frame field is shown on that scale.